### PR TITLE
[21196] Iron: Fix abi break in `rosidl_typesupport_c`

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
@@ -36,16 +36,6 @@ extern "C"
 #endif
 
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_serialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message,
-  eprosima::fastcdr::Cdr & cdr);
-
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_deserialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  eprosima::fastcdr::Cdr &,
-  @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message);
-
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 size_t get_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
   const void * untyped_ros_message,
   size_t current_alignment);

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -140,20 +140,6 @@ for member in message.structure.members:
 @[  if key[0] != package_name]@
 ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
 @[  end if]@
-bool cdr_serialize_@('__'.join(key))(
-  const @('__'.join(key)) * ros_message,
-  eprosima::fastcdr::Cdr & cdr);
-
-@[  if key[0] != package_name]@
-ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
-@[  end if]@
-bool cdr_deserialize_@('__'.join(key))(
-  eprosima::fastcdr::Cdr & cdr,
-  @('__'.join(key)) * ros_message);
-
-@[  if key[0] != package_name]@
-ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
-@[  end if]@
 size_t get_serialized_size_@('__'.join(key))(
   const void * untyped_ros_message,
   size_t current_alignment);
@@ -314,25 +300,15 @@ def generate_member_for_cdr_serialize(member, suffix):
   return strlist
 }@
 
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_serialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message,
+static bool _@(message.structure.namespaced_type.name)__cdr_serialize(
+  const void * untyped_ros_message,
   eprosima::fastcdr::Cdr & cdr)
 {
-@[for member in message.structure.members]@
-@[  for line in generate_member_for_cdr_serialize(member, '')]@
-  @(line)
-@[  end for]@
-
-@[end for]@
-  return true;
-}
-
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_deserialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  eprosima::fastcdr::Cdr & cdr,
-  @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message)
-{
+  if (!untyped_ros_message) {
+    fprintf(stderr, "ros message handle is null\n");
+    return false;
+  }
+  const _@(message.structure.namespaced_type.name)__ros_msg_type * ros_message = static_cast<const _@(message.structure.namespaced_type.name)__ros_msg_type *>(untyped_ros_message);
 @[for member in message.structure.members]@
   // Field name: @(member.name)
   {
@@ -341,6 +317,133 @@ type_ = member.type
 if isinstance(type_, AbstractNestedType):
     type_ = type_.value_type
 }@
+@[  if isinstance(type_, NamespacedType)]@
+    const message_type_support_callbacks_t * callbacks =
+      static_cast<const message_type_support_callbacks_t *>(
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+        rosidl_typesupport_fastrtps_c, @(', '.join(type_.namespaced_name()))
+      )()->data);
+@[  end if]@
+@[  if isinstance(member.type, AbstractNestedType)]@
+@[    if isinstance(member.type, Array)]@
+    size_t size = @(member.type.size);
+    auto array_ptr = ros_message->@(member.name);
+@[    else]@
+    size_t size = ros_message->@(member.name).size;
+    auto array_ptr = ros_message->@(member.name).data;
+@[      if isinstance(member.type, BoundedSequence)]@
+    if (size > @(member.type.maximum_size)) {
+      fprintf(stderr, "array size exceeds upper bound\n");
+      return false;
+    }
+@[      end if]@
+    cdr << static_cast<uint32_t>(size);
+@[    end if]@
+@[    if isinstance(member.type.value_type, AbstractString)]@
+    for (size_t i = 0; i < size; ++i) {
+      const rosidl_runtime_c__String * str = &array_ptr[i];
+      if (str->capacity == 0 || str->capacity <= str->size) {
+        fprintf(stderr, "string capacity not greater than size\n");
+        return false;
+      }
+      if (str->data[str->size] != '\0') {
+        fprintf(stderr, "string not null-terminated\n");
+        return false;
+      }
+      cdr << str->data;
+    }
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+    std::wstring wstr;
+    for (size_t i = 0; i < size; ++i) {
+      const rosidl_runtime_c__U16String * str = &array_ptr[i];
+      if (str->capacity == 0 || str->capacity <= str->size) {
+        fprintf(stderr, "string capacity not greater than size\n");
+        return false;
+      }
+      if (str->data[str->size] != u'\0') {
+        fprintf(stderr, "string not null-terminated\n");
+        return false;
+      }
+      rosidl_typesupport_fastrtps_c::u16string_to_wstring(*str, wstr);
+      cdr << wstr;
+    }
+@[    elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+    for (size_t i = 0; i < size; ++i) {
+      if (!callbacks->cdr_serialize(
+          static_cast<wchar_t *>(&array_ptr[i]), cdr))
+      {
+        return false;
+      }
+    }
+@[    elif isinstance(member.type.value_type, BasicType)]@
+    cdr.serializeArray(array_ptr, size);
+@[    else]@
+    for (size_t i = 0; i < size; ++i) {
+      if (!callbacks->cdr_serialize(
+          &array_ptr[i], cdr))
+      {
+        return false;
+      }
+    }
+@[    end if]@
+@[  elif isinstance(member.type, AbstractString)]@
+    const rosidl_runtime_c__String * str = &ros_message->@(member.name);
+    if (str->capacity == 0 || str->capacity <= str->size) {
+      fprintf(stderr, "string capacity not greater than size\n");
+      return false;
+    }
+    if (str->data[str->size] != '\0') {
+      fprintf(stderr, "string not null-terminated\n");
+      return false;
+    }
+    cdr << str->data;
+@[  elif isinstance(member.type, AbstractWString)]@
+    std::wstring wstr;
+    rosidl_typesupport_fastrtps_c::u16string_to_wstring(ros_message->@(member.name), wstr);
+    cdr << wstr;
+@[  elif isinstance(member.type, BasicType) and member.type.typename == 'boolean']@
+    cdr << (ros_message->@(member.name) ? true : false);
+@[  elif isinstance(member.type, BasicType) and member.type.typename == 'wchar']@
+    cdr << static_cast<wchar_t>(ros_message->@(member.name));
+@[  elif isinstance(member.type, BasicType)]@
+    cdr << ros_message->@(member.name);
+@[  else]@
+    if (!callbacks->cdr_serialize(
+        &ros_message->@(member.name), cdr))
+    {
+      return false;
+    }
+@[  end if]@
+  }
+
+@[end for]@
+  return true;
+}
+
+static bool _@(message.structure.namespaced_type.name)__cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  void * untyped_ros_message)
+{
+  if (!untyped_ros_message) {
+    fprintf(stderr, "ros message handle is null\n");
+    return false;
+  }
+  _@(message.structure.namespaced_type.name)__ros_msg_type * ros_message = static_cast<_@(message.structure.namespaced_type.name)__ros_msg_type *>(untyped_ros_message);
+@[for member in message.structure.members]@
+  // Field name: @(member.name)
+  {
+@{
+type_ = member.type
+if isinstance(type_, AbstractNestedType):
+    type_ = type_.value_type
+}@
+@[  if isinstance(type_, NamespacedType)]@
+    const message_type_support_callbacks_t * callbacks =
+      static_cast<const message_type_support_callbacks_t *>(
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+        rosidl_typesupport_fastrtps_c, @(', '.join(type_.namespaced_name()))
+      )()->data);
+@[  end if]@
 @[  if isinstance(member.type, AbstractNestedType)]@
 @[    if isinstance(member.type, Array)]@
     size_t size = @(member.type.size);
@@ -421,7 +524,11 @@ else:
     cdr.deserializeArray(array_ptr, size);
 @[    else]@
     for (size_t i = 0; i < size; ++i) {
-      cdr_deserialize_@('__'.join(member.type.value_type.namespaced_name()))(cdr, &array_ptr[i]);
+      if (!callbacks->cdr_deserialize(
+          cdr, &array_ptr[i]))
+      {
+        return false;
+      }
     }
 @[    end if]@
 @[   elif isinstance(member.type, AbstractString)]@
@@ -460,7 +567,11 @@ else:
 @[  elif isinstance(member.type, BasicType)]@
     cdr >> ros_message->@(member.name);
 @[  else]@
-    cdr_deserialize_@('__'.join(member.type.namespaced_name()))(cdr, &ros_message->@(member.name));
+    if (!callbacks->cdr_deserialize(
+        cdr, &ros_message->@(member.name)))
+    {
+      return false;
+    }
 @[  end if]@
   }
 
@@ -865,32 +976,6 @@ static message_type_support_key_callbacks_t __key_callbacks_@(message.structure.
 
 @
 @# // Collect the callback functions and provide a function to get the type support struct.
-
-static bool _@(message.structure.namespaced_type.name)__cdr_serialize(
-  const void * untyped_ros_message,
-  eprosima::fastcdr::Cdr & cdr)
-{
-  if (!untyped_ros_message) {
-    fprintf(stderr, "ros message handle is null\n");
-    return false;
-  }
-  const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message = static_cast<const @('__'.join(message.structure.namespaced_type.namespaced_name())) *>(untyped_ros_message);
-  (void)ros_message;
-  return cdr_serialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(ros_message, cdr);
-}
-
-static bool _@(message.structure.namespaced_type.name)__cdr_deserialize(
-  eprosima::fastcdr::Cdr & cdr,
-  void * untyped_ros_message)
-{
-  if (!untyped_ros_message) {
-    fprintf(stderr, "ros message handle is null\n");
-    return false;
-  }
-  @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message = static_cast<@('__'.join(message.structure.namespaced_type.namespaced_name())) *>(untyped_ros_message);
-  (void)ros_message;
-  return cdr_deserialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(cdr, ros_message);
-}
 
 static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(const void * untyped_ros_message)
 {


### PR DESCRIPTION
#4 introduced an ABI break since it takes for granted that  `cdr_serialize()` and `cdr_deserialize()` methods are exported by all the types. However thats not true, specially when the installation of the system is made from binaries.

This PR refactors back those methods not to depend on any external symbol but the `_callbacks` message structure.