### PR TITLE
[21196] Humble: Fix abi break in `rosidl_typesupport_c`

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
@@ -36,16 +36,6 @@ extern "C"
 #endif
 
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_serialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message,
-  eprosima::fastcdr::Cdr & cdr);
-
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
-bool cdr_deserialize_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-  eprosima::fastcdr::Cdr &,
-  @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message);
-
-ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 size_t get_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
   const void * untyped_ros_message,
   size_t current_alignment);


### PR DESCRIPTION
#5 introduced an ABI break since it takes for granted that  `cdr_serialize()` and `cdr_deserialize()` methods are exported by all the types. However thats not true, specially when the installation of the system is made from binaries.

This PR refactors back those methods not to depend on any external symbol but the `_callbacks` message structure.